### PR TITLE
Monkeypatched and ran through prettier js

### DIFF
--- a/xml.js
+++ b/xml.js
@@ -1,3 +1,7 @@
+// THIS IS A MONKEYPATCHED VERSION THAT WORKS IN A BROWSER
+// louis_boyle@hotmail.com
+// github.com/LBoyle 
+
 /*
 	JavaScript XML Library
 	Plus a bunch of object utility functions
@@ -24,14 +28,16 @@
 	This version is for Node.JS, converted in 2012.
 */
 
-var fs = require('fs');
+// This fs module prevents the package from working in the browser
+
+// var fs = require('fs');
 var util = require('util');
 
 var isArray = Array.isArray || util.isArray; // support for older Node.js
 
 var xml_header = '<?xml version="1.0"?>';
 var sort_args = null;
-var re_valid_tag_name  = /^\w[\w\-\:\.]*$/;
+var re_valid_tag_name = /^\w[\w\-\:\.]*$/;
 
 var XML = exports.XML = exports.Parser = function XML(args, opts) {
 	// class constructor for XML parser class
@@ -41,35 +47,43 @@ var XML = exports.XML = exports.Parser = function XML(args, opts) {
 		for (var key in args) this[key] = args[key];
 	}
 	else this.text = args || '';
-	
+
 	// options may be 2nd argument as well
 	if (opts) {
 		for (var key in opts) this[key] = opts[key];
 	}
-	
+
 	// stringify buffers
 	if (this.text instanceof Buffer) {
 		this.text = this.text.toString();
 	}
-	
-	if (!this.text.match(/^\s*</)) {
-		// try as file path
-		var file = this.text;
-		this.text = fs.readFileSync(file, { encoding: 'utf8' });
-		if (!this.text) throw new Error("File not found: " + file);
-	}
-	
+
+	// This fs module prevents the package from working in the browser
+	// Simply not running the check solves this problem. 
+	// My use-case in particular is to parse a response from a request to AWS, 
+	// which is plain XML, and not a file. 
+
+	// The real fix should use window.FileReader. 
+	// I have written some bindings for FileReader, so maybe I should do it? 
+
+	// if (!this.text.match(/^\s*</)) {
+	// 	// try as file path
+	// 	var file = this.text;
+	// 	this.text = fs.readFileSync(file, { encoding: 'utf8' });
+	// 	if (!this.text) throw new Error("File not found: " + file);
+	// }
+
 	this.tree = {};
 	this.errors = [];
 	this.piNodeList = [];
 	this.dtdNodeList = [];
 	this.documentNodeName = '';
-	
+
 	if (this.lowerCase) {
 		this.attribsKey = this.attribsKey.toLowerCase();
 		this.dataKey = this.dataKey.toLowerCase();
 	}
-	
+
 	this.patTag.lastIndex = 0;
 	if (this.text) this.parse();
 }
@@ -102,24 +116,24 @@ XML.prototype.patCDATANode = /^\s*\!\s*\[\s*CDATA\s*\[([^]*)\]\]/;
 XML.prototype.attribsKey = '_Attribs';
 XML.prototype.dataKey = '_Data';
 
-XML.prototype.parse = function(branch, name) {
+XML.prototype.parse = function (branch, name) {
 	// parse text into XML tree, recurse for nested nodes
 	if (!branch) branch = this.tree;
 	if (!name) name = null;
 	var foundClosing = false;
 	var matches = null;
-	
+
 	// match each tag, plus preceding text
-	while ( matches = this.patTag.exec(this.text) ) {
+	while (matches = this.patTag.exec(this.text)) {
 		var before = matches[1];
 		var tag = matches[2];
-		
+
 		// text leading up to tag = content of parent node
 		if (before.match(/\S/)) {
-			if (typeof(branch[this.dataKey]) != 'undefined') branch[this.dataKey] += ' '; else branch[this.dataKey] = '';
+			if (typeof (branch[this.dataKey]) != 'undefined') branch[this.dataKey] += ' '; else branch[this.dataKey] = '';
 			branch[this.dataKey] += !this.preserveWhitespace ? trim(decode_entities(before)) : decode_entities(before);
 		}
-		
+
 		// parse based on tag type
 		if (tag.match(this.patSpecialTag)) {
 			// special tag
@@ -128,14 +142,14 @@ XML.prototype.parse = function(branch, name) {
 			else if (tag.match(this.patDTDTag)) tag = this.parseDTDNode(tag);
 			else if (tag.match(this.patCDATATag)) {
 				tag = this.parseCDATANode(tag);
-				if (typeof(branch[this.dataKey]) != 'undefined') branch[this.dataKey] += ' '; else branch[this.dataKey] = '';
+				if (typeof (branch[this.dataKey]) != 'undefined') branch[this.dataKey] += ' '; else branch[this.dataKey] = '';
 				branch[this.dataKey] += !this.preserveWhitespace ? trim(decode_entities(tag)) : decode_entities(tag);
 			} // cdata
 			else {
-				this.throwParseError( "Malformed special tag", tag );
+				this.throwParseError("Malformed special tag", tag);
 				break;
 			} // error
-			
+
 			if (tag == null) break;
 			continue;
 		} // special tag
@@ -143,14 +157,14 @@ XML.prototype.parse = function(branch, name) {
 			// Tag is standard, so parse name and attributes (if any)
 			var matches = tag.match(this.patStandardTag);
 			if (!matches) {
-				this.throwParseError( "Malformed tag", tag );
+				this.throwParseError("Malformed tag", tag);
 				break;
 			}
-			
+
 			var closing = matches[1];
 			var nodeName = this.lowerCase ? matches[2].toLowerCase() : matches[2];
 			var attribsRaw = matches[3];
-			
+
 			// If this is a closing tag, make sure it matches its opening tag
 			if (closing) {
 				if (nodeName == (name || '')) {
@@ -158,7 +172,7 @@ XML.prototype.parse = function(branch, name) {
 					break;
 				}
 				else {
-					this.throwParseError( "Mismatched closing tag (expected </" + name + ">)", tag );
+					this.throwParseError("Mismatched closing tag (expected </" + name + ">)", tag);
 					break;
 				}
 			} // closing tag
@@ -168,74 +182,74 @@ XML.prototype.parse = function(branch, name) {
 				var selfClosing = !!attribsRaw.match(this.patSelfClosing);
 				var leaf = {};
 				var attribs = leaf;
-				
+
 				// preserve attributes means they go into a sub-hash named "_Attribs"
 				// the XML composer honors this for restoring the tree back into XML
 				if (this.preserveAttributes) {
 					leaf[this.attribsKey] = {};
 					attribs = leaf[this.attribsKey];
 				}
-				
+
 				// parse attributes
 				this.patAttrib.lastIndex = 0;
-				while ( matches = this.patAttrib.exec(attribsRaw) ) {
+				while (matches = this.patAttrib.exec(attribsRaw)) {
 					var key = this.lowerCase ? matches[1].toLowerCase() : matches[1];
-					attribs[ key ] = decode_entities( matches[3] );
+					attribs[key] = decode_entities(matches[3]);
 				} // foreach attrib
-				
+
 				// if no attribs found, but we created the _Attribs subhash, clean it up now
 				if (this.preserveAttributes && !num_keys(attribs)) {
 					delete leaf[this.attribsKey];
 				}
-				
+
 				// Recurse for nested nodes
 				if (!selfClosing) {
-					this.parse( leaf, nodeName );
+					this.parse(leaf, nodeName);
 					if (this.error()) break;
 				}
-				
+
 				// Compress into simple node if text only
 				var num_leaf_keys = num_keys(leaf);
-				if ((typeof(leaf[this.dataKey]) != 'undefined') && (num_leaf_keys == 1)) {
+				if ((typeof (leaf[this.dataKey]) != 'undefined') && (num_leaf_keys == 1)) {
 					leaf = leaf[this.dataKey];
 				}
 				else if (!num_leaf_keys) {
 					leaf = '';
 				}
-				
+
 				// Add leaf to parent branch
-				if (typeof(branch[nodeName]) != 'undefined') {
+				if (typeof (branch[nodeName]) != 'undefined') {
 					if (isa_array(branch[nodeName])) {
-						branch[nodeName].push( leaf );
+						branch[nodeName].push(leaf);
 					}
 					else {
 						var temp = branch[nodeName];
-						branch[nodeName] = [ temp, leaf ];
+						branch[nodeName] = [temp, leaf];
 					}
 				}
 				else if (this.forceArrays && (branch != this.tree)) {
-					branch[nodeName] = [ leaf ];
+					branch[nodeName] = [leaf];
 				}
 				else {
 					branch[nodeName] = leaf;
 				}
-				
+
 				if (this.error() || (branch == this.tree)) break;
 			} // not closing
 		} // standard tag
 	} // main reg exp
-	
+
 	// Make sure we found the closing tag
 	if (name && !foundClosing) {
-		this.throwParseError( "Missing closing tag (expected </" + name + ">)", name );
+		this.throwParseError("Missing closing tag (expected </" + name + ">)", name);
 	}
-	
+
 	// If we are the master node, finish parsing and setup our doc node
 	if (branch == this.tree) {
-		if (typeof(this.tree[this.dataKey]) != 'undefined') delete this.tree[this.dataKey];
-		
+		if (typeof (this.tree[this.dataKey]) != 'undefined') delete this.tree[this.dataKey];
+
 		if (num_keys(this.tree) > 1) {
-			this.throwParseError( 'Only one top-level node is allowed in document', first_key(this.tree) );
+			this.throwParseError('Only one top-level node is allowed in document', first_key(this.tree));
 			return;
 		}
 
@@ -246,30 +260,30 @@ XML.prototype.parse = function(branch, name) {
 	}
 };
 
-XML.prototype.throwParseError = function(key, tag) {
+XML.prototype.throwParseError = function (key, tag) {
 	// log error and locate current line number in source XML document
 	var parsedSource = this.text.substring(0, this.patTag.lastIndex);
 	var eolMatch = parsedSource.match(/\n/g);
 	var lineNum = (eolMatch ? eolMatch.length : 0) + 1;
 	lineNum -= tag.match(/\n/) ? tag.match(/\n/g).length : 0;
-	
-	this.errors.push({ 
+
+	this.errors.push({
 		type: 'Parse',
 		key: key,
 		text: '<' + tag + '>',
 		line: lineNum
 	});
-	
+
 	// Throw actual error (must wrap parse in try/catch)
-	throw new Error( this.getLastError() );
+	throw new Error(this.getLastError());
 };
 
-XML.prototype.error = function() {
+XML.prototype.error = function () {
 	// return number of errors
 	return this.errors.length;
 };
 
-XML.prototype.getError = function(error) {
+XML.prototype.getError = function (error) {
 	// get formatted error
 	var text = '';
 	if (!error) return '';
@@ -277,131 +291,131 @@ XML.prototype.getError = function(error) {
 	text = (error.type || 'General') + ' Error';
 	if (error.code) text += ' ' + error.code;
 	text += ': ' + error.key;
-	
+
 	if (error.line) text += ' on line ' + error.line;
 	if (error.text) text += ': ' + error.text;
 
 	return text;
 };
 
-XML.prototype.getLastError = function() {
+XML.prototype.getLastError = function () {
 	// Get most recently thrown error in plain text format
 	if (!this.error()) return '';
-	return this.getError( this.errors[this.errors.length - 1] );
+	return this.getError(this.errors[this.errors.length - 1]);
 };
 
-XML.prototype.parsePINode = function(tag) {
+XML.prototype.parsePINode = function (tag) {
 	// Parse Processor Instruction Node, e.g. <?xml version="1.0"?>
 	if (!tag.match(this.patPINode)) {
-		this.throwParseError( "Malformed processor instruction", tag );
+		this.throwParseError("Malformed processor instruction", tag);
 		return null;
 	}
-	
-	this.piNodeList.push( tag );
+
+	this.piNodeList.push(tag);
 	return tag;
 };
 
-XML.prototype.parseCommentNode = function(tag) {
+XML.prototype.parseCommentNode = function (tag) {
 	// Parse Comment Node, e.g. <!-- hello -->
 	var matches = null;
 	this.patNextClose.lastIndex = this.patTag.lastIndex;
-	
+
 	while (!tag.match(this.patEndComment)) {
 		if (matches = this.patNextClose.exec(this.text)) {
 			tag += '>' + matches[1];
 		}
 		else {
-			this.throwParseError( "Unclosed comment tag", tag );
+			this.throwParseError("Unclosed comment tag", tag);
 			return null;
 		}
 	}
-	
+
 	this.patTag.lastIndex = this.patNextClose.lastIndex;
 	return tag;
 };
 
-XML.prototype.parseDTDNode = function(tag) {
+XML.prototype.parseDTDNode = function (tag) {
 	// Parse Document Type Descriptor Node, e.g. <!DOCTYPE ... >
 	var matches = null;
-	
+
 	if (tag.match(this.patExternalDTDNode)) {
 		// tag is external, and thus self-closing
-		this.dtdNodeList.push( tag );
+		this.dtdNodeList.push(tag);
 	}
 	else if (tag.match(this.patInlineDTDNode)) {
 		// Tag is inline, so check for nested nodes.
 		this.patNextClose.lastIndex = this.patTag.lastIndex;
-		
+
 		while (!tag.match(this.patEndDTD)) {
 			if (matches = this.patNextClose.exec(this.text)) {
 				tag += '>' + matches[1];
 			}
 			else {
-				this.throwParseError( "Unclosed DTD tag", tag );
+				this.throwParseError("Unclosed DTD tag", tag);
 				return null;
 			}
 		}
-		
+
 		this.patTag.lastIndex = this.patNextClose.lastIndex;
-		
+
 		// Make sure complete tag is well-formed, and push onto DTD stack.
 		if (tag.match(this.patDTDNode)) {
-			this.dtdNodeList.push( tag );
+			this.dtdNodeList.push(tag);
 		}
 		else {
-			this.throwParseError( "Malformed DTD tag", tag );
+			this.throwParseError("Malformed DTD tag", tag);
 			return null;
 		}
 	}
 	else {
-		this.throwParseError( "Malformed DTD tag", tag );
+		this.throwParseError("Malformed DTD tag", tag);
 		return null;
 	}
-	
+
 	return tag;
 };
 
-XML.prototype.parseCDATANode = function(tag) {
+XML.prototype.parseCDATANode = function (tag) {
 	// Parse CDATA Node, e.g. <![CDATA[Brooks & Shields]]>
 	var matches = null;
 	this.patNextClose.lastIndex = this.patTag.lastIndex;
-	
+
 	while (!tag.match(this.patEndCDATA)) {
 		if (matches = this.patNextClose.exec(this.text)) {
 			tag += '>' + matches[1];
 		}
 		else {
-			this.throwParseError( "Unclosed CDATA tag", tag );
+			this.throwParseError("Unclosed CDATA tag", tag);
 			return null;
 		}
 	}
-	
+
 	this.patTag.lastIndex = this.patNextClose.lastIndex;
-	
+
 	if (matches = tag.match(this.patCDATANode)) {
 		return matches[1];
 	}
 	else {
-		this.throwParseError( "Malformed CDATA tag", tag );
+		this.throwParseError("Malformed CDATA tag", tag);
 		return null;
 	}
 };
 
-XML.prototype.getTree = function() {
+XML.prototype.getTree = function () {
 	// get reference to parsed XML tree
 	return this.tree;
 };
 
-XML.prototype.compose = function(indent_string, eol) {
+XML.prototype.compose = function (indent_string, eol) {
 	// compose tree back into XML
-	if (typeof(eol) == 'undefined') eol = "\n";
+	if (typeof (eol) == 'undefined') eol = "\n";
 	var tree = this.tree;
 	if (this.preserveDocumentNode) tree = tree[this.documentNodeName];
-	
-	var raw = compose_xml( tree, this.documentNodeName, 0, indent_string, eol );
+
+	var raw = compose_xml(tree, this.documentNodeName, 0, indent_string, eol);
 	var body = raw.replace(/^\s*\<\?.+?\?\>\s*/, '');
 	var xml = '';
-	
+
 	if (this.piNodeList.length) {
 		for (var idx = 0, len = this.piNodeList.length; idx < len; idx++) {
 			xml += '<' + this.piNodeList[idx] + '>' + eol;
@@ -410,13 +424,13 @@ XML.prototype.compose = function(indent_string, eol) {
 	else {
 		xml += xml_header + eol;
 	}
-	
+
 	if (this.dtdNodeList.length) {
 		for (var idx = 0, len = this.dtdNodeList.length; idx < len; idx++) {
 			xml += '<' + this.dtdNodeList[idx] + '>' + eol;
 		}
 	}
-	
+
 	xml += body;
 	return xml;
 };
@@ -436,32 +450,32 @@ var parse_xml = exports.parse = function parse_xml(text, opts) {
 var trim = exports.trim = function trim(text) {
 	// strip whitespace from beginning and end of string
 	if (text == null) return '';
-	
+
 	if (text && text.replace) {
 		text = text.replace(/^\s+/, "");
 		text = text.replace(/\s+$/, "");
 	}
-	
+
 	return text;
 };
 
 var encode_entities = exports.encodeEntities = function encode_entities(text) {
 	// Simple entitize exports.for = function for composing XML
 	if (text == null) return '';
-	
+
 	if (text && text.replace) {
 		text = text.replace(/\&/g, "&amp;"); // MUST BE FIRST
 		text = text.replace(/</g, "&lt;");
 		text = text.replace(/>/g, "&gt;");
 	}
-	
+
 	return text;
 };
 
 var encode_attrib_entities = exports.encodeAttribEntities = function encode_attrib_entities(text) {
 	// Simple entitize exports.for = function for composing XML attributes
 	if (text == null) return '';
-	
+
 	if (text && text.replace) {
 		text = text.replace(/\&/g, "&amp;"); // MUST BE FIRST
 		text = text.replace(/</g, "&lt;");
@@ -469,14 +483,14 @@ var encode_attrib_entities = exports.encodeAttribEntities = function encode_attr
 		text = text.replace(/\"/g, "&quot;");
 		text = text.replace(/\'/g, "&apos;");
 	}
-	
+
 	return text;
 };
 
 var decode_entities = exports.decodeEntities = function decode_entities(text) {
 	// Decode XML entities into raw ASCII
 	if (text == null) return '';
-	
+
 	if (text && text.replace && text.match(/\&/)) {
 		text = text.replace(/\&lt\;/g, "<");
 		text = text.replace(/\&gt\;/g, ">");
@@ -484,45 +498,45 @@ var decode_entities = exports.decodeEntities = function decode_entities(text) {
 		text = text.replace(/\&apos\;/g, "'");
 		text = text.replace(/\&amp\;/g, "&"); // MUST BE LAST
 	}
-	
+
 	return text;
 };
 
 var compose_xml = exports.stringify = function compose_xml(node, name, indent, indent_string, eol, sort) {
 	// Compose node into XML including attributes
 	// Recurse for child nodes
-	if (typeof(indent_string) == 'undefined') indent_string = "\t";
-	if (typeof(eol) == 'undefined') eol = "\n";
-	if (typeof(sort) == 'undefined') sort = true;
+	if (typeof (indent_string) == 'undefined') indent_string = "\t";
+	if (typeof (eol) == 'undefined') eol = "\n";
+	if (typeof (sort) == 'undefined') sort = true;
 	var xml = "";
-	
+
 	// If this is the root node, set the indent to 0
 	// and setup the XML header (PI node)
 	if (!indent) {
 		indent = 0;
 		xml = xml_header + eol;
-		
+
 		if (!name) {
 			// no name provided, assume content is wrapped in it
 			name = first_key(node);
 			node = node[name];
 		}
 	}
-	
+
 	// Setup the indent text
 	var indent_text = "";
 	for (var k = 0; k < indent; k++) indent_text += indent_string;
-	
-	if ((typeof(node) == 'object') && (node != null)) {
+
+	if ((typeof (node) == 'object') && (node != null)) {
 		// node is object -- now see if it is an array or hash
 		if (!node.length) { // what about zero-length array?
 			// node is hash
 			xml += indent_text + "<" + name;
-			
+
 			var num_keys = 0;
 			var has_attribs = 0;
 			for (var key in node) num_keys++; // there must be a better way...
-			
+
 			if (node["_Attribs"]) {
 				has_attribs = 1;
 				var sorted_keys = sort ? hash_keys_to_array(node["_Attribs"]).sort() : hash_keys_to_array(node["_Attribs"]);
@@ -531,27 +545,27 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 					xml += " " + key + "=\"" + encode_attrib_entities(node["_Attribs"][key]) + "\"";
 				}
 			} // has attribs
-			
+
 			if (num_keys > has_attribs) {
 				// has child elements
 				xml += ">";
-				
+
 				if (node["_Data"]) {
 					// simple text child node
 					xml += encode_entities(node["_Data"]) + "</" + name + ">" + eol;
 				} // just text
 				else {
 					xml += eol;
-					
+
 					var sorted_keys = sort ? hash_keys_to_array(node).sort() : hash_keys_to_array(node);
 					for (var idx = 0, len = sorted_keys.length; idx < len; idx++) {
-						var key = sorted_keys[idx];					
+						var key = sorted_keys[idx];
 						if ((key != "_Attribs") && key.match(re_valid_tag_name)) {
 							// recurse for node, with incremented indent value
-							xml += compose_xml( node[key], key, indent + 1, indent_string, eol, sort );
+							xml += compose_xml(node[key], key, indent + 1, indent_string, eol, sort);
 						} // not _Attribs key
 					} // foreach key
-					
+
 					xml += indent_text + "</" + name + ">" + eol;
 				} // real children
 			}
@@ -564,7 +578,7 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 			// node is array
 			for (var idx = 0; idx < node.length; idx++) {
 				// recurse for node in array with same indent
-				xml += compose_xml( node[idx], name, indent, indent_string, eol, sort );
+				xml += compose_xml(node[idx], name, indent, indent_string, eol, sort);
 			}
 		} // array of nodes
 	} // complex node
@@ -572,7 +586,7 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 		// node is simple string
 		xml += indent_text + "<" + name + ">" + encode_entities(node) + "</" + name + ">" + eol;
 	} // simple text node
-	
+
 	return xml;
 };
 
@@ -580,7 +594,7 @@ var always_array = exports.alwaysArray = function always_array(obj, key) {
 	// if object is not array, return array containing object
 	// if key is passed, work like XMLalwaysarray() instead
 	if (key) {
-		if ((typeof(obj[key]) != 'object') || (typeof(obj[key].length) == 'undefined')) {
+		if ((typeof (obj[key]) != 'object') || (typeof (obj[key].length) == 'undefined')) {
 			var temp = obj[key];
 			delete obj[key];
 			obj[key] = new Array();
@@ -589,7 +603,7 @@ var always_array = exports.alwaysArray = function always_array(obj, key) {
 		return null;
 	}
 	else {
-		if ((typeof(obj) != 'object') || (typeof(obj.length) == 'undefined')) { return [ obj ]; }
+		if ((typeof (obj) != 'object') || (typeof (obj.length) == 'undefined')) { return [obj]; }
 		else return obj;
 	}
 };
@@ -608,7 +622,7 @@ var isa_array = exports.isaArray = function isa_array(arg) {
 
 var isa_hash = exports.isaHash = function isa_hash(arg) {
 	// determine if arg is a hash
-	return( !!arg && (typeof(arg) == 'object') && !isa_array(arg) );
+	return (!!arg && (typeof (arg) == 'object') && !isa_array(arg));
 };
 
 var first_key = exports.firstKey = function first_key(hash) {


### PR DESCRIPTION
The original package uses fs.readFileSync in case the xml input is a file, but for my use-case in particular, it's not a file, so I don't need to run the check or readFileSync on it at all. 

This removes the only dependency that doesn't work in the browser, so this will work in the browser. 

To restore this functionality we could use window.FileReader instead of fs. Perhaps I should do it? 